### PR TITLE
Scanning a local file headers is not necessary

### DIFF
--- a/zipEntry.js
+++ b/zipEntry.js
@@ -15,7 +15,8 @@ module.exports = function (/*Buffer*/ input) {
         if (!input || !Buffer.isBuffer(input)) {
             return Buffer.alloc(0);
         }
-        _entryHeader.loadDataHeaderFromBinary(input);
+        //Scanning a local file headers is not necessary (except in the case of corrupted archives)
+        if(!_entryHeader.compressedSize) _entryHeader.loadDataHeaderFromBinary(input);
         return input.slice(_entryHeader.realDataOffset, _entryHeader.realDataOffset + _entryHeader.compressedSize);
     }
 


### PR DESCRIPTION
Scanning a local file headers is not necessary (except in the case of corrupted archives) https://en.wikipedia.org/wiki/ZIP_(file_format)#Structure